### PR TITLE
Fix isVolunteer bug, rewrite broken tests, clean up controller

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -46,16 +46,6 @@ public class UserController {
     }
 
 
-    //Chammer probably lösche!! nomal ahluege
-    @GetMapping("/users/{id}/profile")
-    @ResponseStatus(HttpStatus.OK)
-    @ResponseBody
-    public UserGetDTO getUserProfile(@PathVariable String id) {
-        User foundUser = userService.getUserById(id);
-        return DTOMapper.INSTANCE.convertEntityToUserGetDTO(foundUser);
-    }
-
-
     @PutMapping("/profile/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ResponseBody

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -83,12 +83,16 @@ public class User implements Serializable {
 	}
 
 
-    public boolean isVolunteer() {
+    // Using getIsVolunteer/setIsVolunteer naming so that Jackson correctly
+    // serializes this field as "isVolunteer" in JSON (not "volunteer").
+    // The standard JavaBeans convention for boolean isX() would make Jackson
+    // strip the "is" prefix, causing a mismatch with what the client sends.
+    public boolean getIsVolunteer() {
         return isVolunteer;
     }
 
-    public void setVolunteer(boolean volunteer) {
-        isVolunteer = volunteer;
+    public void setIsVolunteer(boolean isVolunteer) {
+        this.isVolunteer = isVolunteer;
     }
 
     public String getUsername() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
@@ -1,84 +1,42 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import java.time.LocalDate;
 
 public class UserGetDTO {
 
-	private String id;
-	private String name;
-	private String username;
-	private String bio;
-	private LocalDate dateOfBirth;
-	private String gender;
-	private String token;
+    private String id;
+    private String username;
     private String surname;
     private String lastname;
     private String emailAddress;
     private String phoneNumber;
     private String address;
+    private String bio;
+    private LocalDate dateOfBirth;
+    private String gender;
+    private String token;
     private Boolean isVolunteer;
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getUsername() {
+        return username;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-	public String getBio() {
-		return bio;
-	}
-
-	public void setBio (String bio) {
-		this.bio = bio;
-	}
-
-	public LocalDate getDateOfBirth () {
-		return dateOfBirth;
-	}
-
-	public void setDateOfBirth (LocalDate dateOfBirth) {
-		this.dateOfBirth = dateOfBirth;
-	}
-
-	public String getGender() {
-		return gender;
-	}
-
-	public void setGender (String gender) {
-		this.gender = gender;
-	}
-
-	
-	public String getToken() {
-		return token;
-	}
-
-	public void setToken(String token) {
-		this.token = token;
-	}
+    public void setUsername(String username) {
+        this.username = username;
+    }
 
     public String getSurname() {
         return surname;
     }
+
     public void setSurname(String surname) {
         this.surname = surname;
     }
@@ -86,15 +44,19 @@ public class UserGetDTO {
     public String getLastname() {
         return lastname;
     }
+
     public void setLastname(String lastname) {
         this.lastname = lastname;
     }
+
     public String getEmailAddress() {
         return emailAddress;
     }
+
     public void setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
     }
+
     public String getPhoneNumber() {
         return phoneNumber;
     }
@@ -102,6 +64,7 @@ public class UserGetDTO {
     public void setPhoneNumber(String phoneNumber) {
         this.phoneNumber = phoneNumber;
     }
+
     public String getAddress() {
         return address;
     }
@@ -109,6 +72,39 @@ public class UserGetDTO {
     public void setAddress(String address) {
         this.address = address;
     }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
     public Boolean getIsVolunteer() {
         return isVolunteer;
     }
@@ -116,6 +112,4 @@ public class UserGetDTO {
     public void setIsVolunteer(Boolean isVolunteer) {
         this.isVolunteer = isVolunteer;
     }
-
-
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -59,12 +59,14 @@ public class UserPostDTO {
         this.emailAddress = emailAddress;
     }
 
-    public boolean isVolunteer() {
+    // Using getIsVolunteer/setIsVolunteer so Jackson maps JSON "isVolunteer" correctly.
+    // The isVolunteer() getter convention would make Jackson look for "volunteer" instead.
+    public boolean getIsVolunteer() {
         return isVolunteer;
     }
 
-    public void setVolunteer(boolean volunteer) {
-        isVolunteer = volunteer;
+    public void setIsVolunteer(boolean isVolunteer) {
+        this.isVolunteer = isVolunteer;
     }
 
     public String getBio() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -2,7 +2,6 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
-import org.mapstruct.ReportingPolicy;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.entity.Inserat;
@@ -14,40 +13,37 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.InseratPostDTO;
 
 /**
  * DTOMapper
- * This class is responsible for generating classes that will automatically
- * transform/map the internal representation
- * of an entity (e.g., the User) to the external/API representation (e.g.,
- * UserGetDTO for getting, UserPostDTO for creating)
- * and vice versa.
- * Additional mappers can be defined for new entities.
- * Always created one mapper for getting information (GET) and one mapper for
- * creating information (POST).
+ * Responsible for mapping between internal entity representations and
+ * external API representations (DTOs).
+ *
+ * Notes on boolean field mapping:
+ * - User entity and all DTOs use getIsVolunteer()/setIsVolunteer() naming
+ *   so that Jackson serializes/deserializes the JSON field as "isVolunteer".
+ * - MapStruct sees the property name as "isVolunteer" on both sides,
+ *   so no explicit @Mapping is needed for this field.
  */
 @Mapper
 public interface DTOMapper {
 
     DTOMapper INSTANCE = Mappers.getMapper(DTOMapper.class);
 
+    // PostDTO -> Entity: all fields match by name (including isVolunteer)
     User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
-    @Mapping(source = "volunteer", target = "isVolunteer")
-    @Mapping(target = "name", ignore = true)
+    // Entity -> GetDTO: all fields match by name. No "name" field exists
+    // on User entity, so we don't map it.
     UserGetDTO convertEntityToUserGetDTO(User user);
 
-    @Mapping(source = "username", target = "username")
-    @Mapping(source = "password", target = "password")
-    @Mapping(source = "surname", target = "surname")
-    @Mapping(source = "lastname", target = "lastname")
-    @Mapping(source = "emailAddress", target = "emailAddress")
-    @Mapping(source = "isVolunteer", target = "volunteer")
-    @Mapping(source = "bio", target = "bio")
-    @Mapping(source = "address", target = "address")
-    @Mapping(source = "gender", target = "gender")
-    @Mapping(source = "phoneNumber", target = "phoneNumber")
-    @Mapping(source = "dateOfBirth", target = "dateOfBirth")
+    // PutDTO -> Entity: isVolunteer maps automatically since both sides
+    // use getIsVolunteer()/setIsVolunteer().
     User convertUserPutDTOtoEntity(UserPutDTO userPutDTO);
 
-
+    // InseratPostDTO -> Entity: straightforward field mapping
     Inserat convertInseratPostDTOtoEntity(InseratPostDTO inseratPostDTO);
+
+    // Entity -> InseratGetDTO: recipient is a User object on the entity,
+    // but recipientId is a String on the DTO, so we need an explicit mapping
+    // to extract the nested id.
+    @Mapping(source = "recipient.id", target = "recipientId")
     InseratGetDTO convertEntityToInseratGetDTO(Inserat inserat);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -285,7 +285,7 @@ public class UserService {
             existingUser.setEmailAddress(userInput.getEmailAddress().trim());
         }
 
-        existingUser.setVolunteer(userInput.isVolunteer());
+        existingUser.setIsVolunteer(userInput.getIsVolunteer());
 
         if (!isBlank(userInput.getBio())) {
             existingUser.setBio(userInput.getBio().trim());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -1,10 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
@@ -20,10 +17,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,88 +26,142 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * UserControllerTest
- * This is a WebMvcTest which allows to test the UserController i.e. GET/POST
- * request without actually sending them over the network.
- * This tests if the UserController works.
+ * Tests the UserController REST endpoints (GET /profile/{id}, POST /register,
+ * POST /login) using MockMvc without starting a real server.
  */
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-	@MockitoBean
-	private UserService userService;
+    @MockitoBean
+    private UserService userService;
 
-	@Test
-	public void givenUsers_whenGetUsers_thenReturnJsonArray() throws Exception {
-		// given
-		User user = new User();
-		user.setName("Firstname Lastname");
-		user.setUsername("firstname@lastname");
-		user.setStatus(UserStatus.OFFLINE);
+    /**
+     * Helper: creates a fully populated User entity for testing.
+     * All required fields are set to avoid null pointer issues in assertions.
+     */
+    private User createTestUser() {
+        User user = new User();
+        user.setId("test-uuid-123");
+        user.setUsername("testUser");
+        user.setSurname("John");
+        user.setLastname("Doe");
+        user.setPassword("securePassword");
+        user.setEmailAddress("john@example.com");
+        user.setIsVolunteer(false);
+        user.setBio("A short bio");
+        user.setAddress("Zürichstrasse 1");
+        user.setGender("male");
+        user.setPhoneNumber("+41 79 123 45 67");
+        user.setDateOfBirth(java.time.LocalDate.of(2000, 1, 15));
+        user.setToken("random-token-abc");
+        return user;
+    }
 
-		List<User> allUsers = Collections.singletonList(user);
+    @Test
+    public void getProfile_validId_returnsUser() throws Exception {
+        // given: a user exists in the service
+        User user = createTestUser();
+        given(userService.getUserById("test-uuid-123")).willReturn(user);
 
-		// this mocks the UserService -> we define above what the userService should
-		// return when getUsers() is called
-		given(userService.getUsers()).willReturn(allUsers);
+        // when: GET /profile/{id}
+        MockHttpServletRequestBuilder getRequest = get("/profile/test-uuid-123")
+                .contentType(MediaType.APPLICATION_JSON);
 
-		// when
-		MockHttpServletRequestBuilder getRequest = get("/users").contentType(MediaType.APPLICATION_JSON);
+        // then: response contains the user's fields
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is("test-uuid-123")))
+                .andExpect(jsonPath("$.username", is("testUser")))
+                .andExpect(jsonPath("$.surname", is("John")))
+                .andExpect(jsonPath("$.lastname", is("Doe")))
+                .andExpect(jsonPath("$.isVolunteer", is(false)));
+    }
 
-		// then
-		mockMvc.perform(getRequest).andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(1)))
-				.andExpect(jsonPath("$[0].name", is(user.getName())))
-				.andExpect(jsonPath("$[0].username", is(user.getUsername())))
-				.andExpect(jsonPath("$[0].status", is(user.getStatus().toString())));
-	}
+    @Test
+    public void register_validInput_userCreated() throws Exception {
+        // given: service will return a created user with a token
+        User createdUser = createTestUser();
 
-	@Test
-	public void createUser_validInput_userCreated() throws Exception {
-		// given
-		User user = new User();
-		user.setId(1L);
-		user.setName("Test User");
-		user.setUsername("testUsername");
-		user.setToken("1");
-		user.setStatus(UserStatus.ONLINE);
+        UserPostDTO postDTO = new UserPostDTO();
+        postDTO.setUsername("testUser");
+        postDTO.setPassword("securePassword");
+        postDTO.setSurname("John");
+        postDTO.setLastname("Doe");
+        postDTO.setEmailAddress("john@example.com");
+        postDTO.setIsVolunteer(false);
 
-		UserPostDTO userPostDTO = new UserPostDTO();
-		userPostDTO.setName("Test User");
-		userPostDTO.setUsername("testUsername");
+        given(userService.createUser(Mockito.any())).willReturn(createdUser);
 
-		given(userService.createUser(Mockito.any())).willReturn(user);
+        // when: POST /register
+        MockHttpServletRequestBuilder postRequest = post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(postDTO));
 
-		// when/then -> do the request + validate the result
-		MockHttpServletRequestBuilder postRequest = post("/users")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(asJsonString(userPostDTO));
+        // then: status 201 and response contains the user data
+        mockMvc.perform(postRequest)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is("test-uuid-123")))
+                .andExpect(jsonPath("$.username", is("testUser")))
+                .andExpect(jsonPath("$.token", is("random-token-abc")));
+    }
 
-		// then
-		mockMvc.perform(postRequest)
-				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.id", is(user.getId().intValue())))
-				.andExpect(jsonPath("$.name", is(user.getName())))
-				.andExpect(jsonPath("$.username", is(user.getUsername())))
-				.andExpect(jsonPath("$.status", is(user.getStatus().toString())));
-	}
+    @Test
+    public void login_validCredentials_returnsUser() throws Exception {
+        // given: login returns an authorized user with a fresh token
+        User authorizedUser = createTestUser();
+        authorizedUser.setToken("fresh-login-token");
 
-	/**
-	 * Helper Method to convert userPostDTO into a JSON string such that the input
-	 * can be processed
-	 * Input will look like this: {"name": "Test User", "username": "testUsername"}
-	 * 
-	 * @param object
-	 * @return string
-	 */
-	private String asJsonString(final Object object) {
-		try {
-			return new ObjectMapper().writeValueAsString(object);
-		} catch (JacksonException e) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-					String.format("The request body could not be created.%s", e.toString()));
-		}
-	}
+        given(userService.loginUser(Mockito.any())).willReturn(authorizedUser);
+
+        UserPostDTO loginDTO = new UserPostDTO();
+        loginDTO.setUsername("testUser");
+        loginDTO.setPassword("securePassword");
+
+        // when: POST /login
+        MockHttpServletRequestBuilder postRequest = post("/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(loginDTO));
+
+        // then: status 200 and response contains a token
+        mockMvc.perform(postRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is("testUser")))
+                .andExpect(jsonPath("$.token", is("fresh-login-token")));
+    }
+
+    @Test
+    public void login_invalidUsername_returns404() throws Exception {
+        // given: service throws NOT_FOUND for unknown username
+        given(userService.loginUser(Mockito.any())).willThrow(
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "The username provided does not exist!"));
+
+        UserPostDTO loginDTO = new UserPostDTO();
+        loginDTO.setUsername("nonExistentUser");
+        loginDTO.setPassword("anyPassword");
+
+        // when: POST /login
+        MockHttpServletRequestBuilder postRequest = post("/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(loginDTO));
+
+        // then: status 404
+        mockMvc.perform(postRequest)
+                .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Converts an object to its JSON string representation for use as request body.
+     * Uses Jackson's ObjectMapper (tools.jackson package in Spring Boot 4.0).
+     */
+    private String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format("The request body could not be created.%s", e.toString()));
+        }
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
@@ -5,41 +5,89 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+/**
+ * Integration test for UserRepository using @DataJpaTest (H2 in-memory DB).
+ * Tests the custom query methods findByUsername and findByEmailAddress.
+ */
 @DataJpaTest
 public class UserRepositoryIntegrationTest {
 
-	@Autowired
-	private TestEntityManager entityManager;
+    @Autowired
+    private TestEntityManager entityManager;
 
-	@Autowired
-	private UserRepository userRepository;
+    @Autowired
+    private UserRepository userRepository;
 
-	@Test
-	public void findByName_success() {
-		// given
-		User user = new User();
-		user.setName("Firstname Lastname");
-		user.setUsername("firstname@lastname");
-		user.setStatus(UserStatus.OFFLINE);
-		user.setToken("1");
+    /**
+     * Helper: creates and persists a fully populated User entity.
+     * All non-nullable columns must be set for the entity to be valid.
+     */
+    private User persistTestUser() {
+        User user = new User();
+        user.setUsername("testUser");
+        user.setPassword("testPassword");
+        user.setSurname("John");
+        user.setLastname("Doe");
+        user.setEmailAddress("john@example.com");
+        user.setIsVolunteer(true);
+        user.setBio("A bio");
+        user.setAddress("Some Street 1");
+        user.setGender("male");
+        user.setPhoneNumber("+41 79 000 00 00");
+        user.setDateOfBirth(LocalDate.of(2000, 1, 15));
+        user.setToken("test-token");
 
-		entityManager.persist(user);
-		entityManager.flush();
+        entityManager.persist(user);
+        entityManager.flush();
+        return user;
+    }
 
-		// when
-		User found = userRepository.findByName(user.getName());
+    @Test
+    public void findByUsername_success() {
+        // given: a user is persisted in the database
+        User user = persistTestUser();
 
-		// then
-		assertNotNull(found.getId());
-		assertEquals(found.getName(), user.getName());
-		assertEquals(found.getUsername(), user.getUsername());
-		assertEquals(found.getToken(), user.getToken());
-		assertEquals(found.getStatus(), user.getStatus());
-	}
+        // when: searching by username
+        User found = userRepository.findByUsername(user.getUsername());
+
+        // then: the correct user is returned with all fields intact
+        assertNotNull(found);
+        assertNotNull(found.getId());
+        assertEquals("testUser", found.getUsername());
+        assertEquals("John", found.getSurname());
+        assertEquals("Doe", found.getLastname());
+        assertEquals("john@example.com", found.getEmailAddress());
+        assertEquals(true, found.getIsVolunteer());
+    }
+
+    @Test
+    public void findByEmailAddress_success() {
+        // given: a user is persisted in the database
+        User user = persistTestUser();
+
+        // when: searching by email address
+        User found = userRepository.findByEmailAddress(user.getEmailAddress());
+
+        // then: the correct user is returned
+        assertNotNull(found);
+        assertEquals("testUser", found.getUsername());
+        assertEquals("john@example.com", found.getEmailAddress());
+    }
+
+    @Test
+    public void findByUsername_notFound_returnsNull() {
+        // when: searching for a username that doesn't exist
+        User found = userRepository.findByUsername("nonExistentUser");
+
+        // then: null is returned
+        assertNull(found);
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -2,50 +2,76 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 
 import org.junit.jupiter.api.Test;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * DTOMapperTest
- * Tests if the mapping between the internal and the external/API representation
- * works.
+ * Tests that DTOMapper correctly maps between User entity and DTOs.
+ * Verifies that all fields (including the boolean isVolunteer) are
+ * properly transferred in both directions.
  */
 public class DTOMapperTest {
-	@Test
-	public void testCreateUser_fromUserPostDTO_toUser_success() {
-		// create UserPostDTO
-		UserPostDTO userPostDTO = new UserPostDTO();
-		userPostDTO.setName("name");
-		userPostDTO.setUsername("username");
 
-		// MAP -> Create user
-		User user = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
+    @Test
+    public void testCreateUser_fromUserPostDTO_toUser_success() {
+        // create a UserPostDTO with all fields set
+        UserPostDTO userPostDTO = new UserPostDTO();
+        userPostDTO.setUsername("testUser");
+        userPostDTO.setPassword("testPassword");
+        userPostDTO.setSurname("John");
+        userPostDTO.setLastname("Doe");
+        userPostDTO.setEmailAddress("john@example.com");
+        userPostDTO.setIsVolunteer(true);
+        userPostDTO.setBio("A bio");
+        userPostDTO.setAddress("Test Street 1");
+        userPostDTO.setGender("male");
+        userPostDTO.setPhoneNumber("+41 79 000 00 00");
+        userPostDTO.setDateOfBirth(LocalDate.of(2000, 1, 15));
 
-		// check content
-		assertEquals(userPostDTO.getName(), user.getName());
-		assertEquals(userPostDTO.getUsername(), user.getUsername());
-	}
+        // MAP: PostDTO -> User entity
+        User user = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
 
-	@Test
-	public void testGetUser_fromUser_toUserGetDTO_success() {
-		// create User
-		User user = new User();
-		user.setName("Firstname Lastname");
-		user.setUsername("firstname@lastname");
-		user.setStatus(UserStatus.OFFLINE);
-		user.setToken("1");
+        // Verify all fields are mapped correctly
+        assertEquals("testUser", user.getUsername());
+        assertEquals("testPassword", user.getPassword());
+        assertEquals("John", user.getSurname());
+        assertEquals("Doe", user.getLastname());
+        assertEquals("john@example.com", user.getEmailAddress());
+        assertEquals(true, user.getIsVolunteer());
+        assertEquals("A bio", user.getBio());
+    }
 
-		// MAP -> Create UserGetDTO
-		UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
+    @Test
+    public void testGetUser_fromUser_toUserGetDTO_success() {
+        // create a User entity with all fields set
+        User user = new User();
+        user.setId("test-uuid-123");
+        user.setUsername("testUser");
+        user.setSurname("John");
+        user.setLastname("Doe");
+        user.setEmailAddress("john@example.com");
+        user.setIsVolunteer(false);
+        user.setBio("A bio");
+        user.setGender("male");
+        user.setToken("test-token");
+        user.setDateOfBirth(LocalDate.of(2000, 1, 15));
 
-		// check content
-		assertEquals(user.getId(), userGetDTO.getId());
-		assertEquals(user.getName(), userGetDTO.getName());
-		assertEquals(user.getUsername(), userGetDTO.getUsername());
-		assertEquals(user.getStatus(), userGetDTO.getStatus());
-	}
+        // MAP: User entity -> GetDTO
+        UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
+
+        // Verify all fields are mapped correctly
+        assertEquals("test-uuid-123", userGetDTO.getId());
+        assertEquals("testUser", userGetDTO.getUsername());
+        assertEquals("John", userGetDTO.getSurname());
+        assertEquals("Doe", userGetDTO.getLastname());
+        assertEquals("john@example.com", userGetDTO.getEmailAddress());
+        assertEquals(false, userGetDTO.getIsVolunteer());
+        assertEquals("A bio", userGetDTO.getBio());
+        assertEquals("test-token", userGetDTO.getToken());
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -8,70 +8,95 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test class for the UserResource REST resource.
- *
- * @see UserService
+ * Integration test for UserService using a real H2 in-memory database.
+ * Tests the full create-and-login flow without mocking.
  */
 @WebAppConfiguration
 @SpringBootTest
 public class UserServiceIntegrationTest {
 
-	@Qualifier("userRepository")
-	@Autowired
-	private UserRepository userRepository;
+    @Qualifier("userRepository")
+    @Autowired
+    private UserRepository userRepository;
 
-	@Autowired
-	private UserService userService;
+    @Autowired
+    private UserService userService;
 
-	@BeforeEach
-	public void setup() {
-		userRepository.deleteAll();
-	}
+    @BeforeEach
+    public void setup() {
+        userRepository.deleteAll();
+    }
 
-	@Test
-	public void createUser_validInputs_success() {
-		// given
-		assertNull(userRepository.findByUsername("testUsername"));
+    /**
+     * Helper: creates a fully populated User with all required registration fields.
+     */
+    private User createFullUser(String username, String email) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("testPassword");
+        user.setSurname("John");
+        user.setLastname("Doe");
+        user.setEmailAddress(email);
+        user.setIsVolunteer(false);
+        user.setBio("Test bio");
+        user.setAddress("Test Street 1");
+        user.setGender("male");
+        user.setPhoneNumber("+41 79 000 00 00");
+        user.setDateOfBirth(LocalDate.of(2000, 1, 15));
+        return user;
+    }
 
-		User testUser = new User();
-		testUser.setName("testName");
-		testUser.setUsername("testUsername");
+    @Test
+    public void createUser_validInputs_success() {
+        // given: no users in the database
+        assertNull(userRepository.findByUsername("testUser"));
 
-		// when
-		User createdUser = userService.createUser(testUser);
+        User testUser = createFullUser("testUser", "john@example.com");
 
-		// then
-		assertEquals(testUser.getId(), createdUser.getId());
-		assertEquals(testUser.getName(), createdUser.getName());
-		assertEquals(testUser.getUsername(), createdUser.getUsername());
-		assertNotNull(createdUser.getToken());
-		assertEquals(UserStatus.OFFLINE, createdUser.getStatus());
-	}
+        // when: creating the user
+        User createdUser = userService.createUser(testUser);
 
-	@Test
-	public void createUser_duplicateUsername_throwsException() {
-		assertNull(userRepository.findByUsername("testUsername"));
+        // then: user is persisted and auto-logged-in (has a token)
+        assertEquals("testUser", createdUser.getUsername());
+        assertEquals("John", createdUser.getSurname());
+        assertEquals("Doe", createdUser.getLastname());
+        assertNotNull(createdUser.getToken());
+        assertFalse(createdUser.getIsVolunteer());
+    }
 
-		User testUser = new User();
-		testUser.setName("testName");
-		testUser.setUsername("testUsername");
-		userService.createUser(testUser);
+    @Test
+    public void createUser_duplicateUsername_throwsException() {
+        // given: a user already exists with this username
+        assertNull(userRepository.findByUsername("testUser"));
 
-		// attempt to create second user with same username
-		User testUser2 = new User();
+        User firstUser = createFullUser("testUser", "first@example.com");
+        userService.createUser(firstUser);
 
-		// change the name but forget about the username
-		testUser2.setName("testName2");
-		testUser2.setUsername("testUsername");
+        // when: trying to create a second user with the same username
+        User secondUser = createFullUser("testUser", "second@example.com");
 
-		// check that an error is thrown
-		assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser2));
-	}
+        // then: a ResponseStatusException is thrown
+        assertThrows(ResponseStatusException.class, () -> userService.createUser(secondUser));
+    }
+
+    @Test
+    public void createUser_duplicateEmail_throwsException() {
+        // given: a user already exists with this email
+        User firstUser = createFullUser("firstUser", "same@example.com");
+        userService.createUser(firstUser);
+
+        // when: trying to create a second user with the same email
+        User secondUser = createFullUser("secondUser", "same@example.com");
+
+        // then: a ResponseStatusException is thrown
+        assertThrows(ResponseStatusException.class, () -> userService.createUser(secondUser));
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -8,79 +8,130 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for UserService using Mockito to mock the UserRepository.
+ * Tests createUser and loginUser logic in isolation.
+ */
 public class UserServiceTest {
 
-	@Mock
-	private UserRepository userRepository;
+    @Mock
+    private UserRepository userRepository;
 
-	@InjectMocks
-	private UserService userService;
+    @InjectMocks
+    private UserService userService;
 
-	private User testUser;
+    private User testUser;
 
-	@BeforeEach
-	public void setup() {
-		MockitoAnnotations.openMocks(this);
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
 
-		// given
-		testUser = new User();
-		testUser.setId(1L);
-		testUser.setName("testName");
-		testUser.setUsername("testUsername");
+        // Create a fully populated test user (all required fields for registration)
+        testUser = new User();
+        testUser.setUsername("testUser");
+        testUser.setPassword("testPassword");
+        testUser.setSurname("John");
+        testUser.setLastname("Doe");
+        testUser.setEmailAddress("john@example.com");
+        testUser.setIsVolunteer(false);
+        testUser.setBio("Test bio");
+        testUser.setAddress("Test Street 1");
+        testUser.setGender("male");
+        testUser.setPhoneNumber("+41 79 000 00 00");
+        testUser.setDateOfBirth(LocalDate.of(2000, 1, 15));
 
-		// when -> any object is being save in the userRepository -> return the dummy
-		// testUser
-		Mockito.when(userRepository.save(Mockito.any())).thenReturn(testUser);
-	}
+        // When the repository saves any User, return testUser
+        Mockito.when(userRepository.save(Mockito.any())).thenReturn(testUser);
+    }
 
-	@Test
-	public void createUser_validInputs_success() {
-		// when -> any object is being save in the userRepository -> return the dummy
-		// testUser
-		User createdUser = userService.createUser(testUser);
+    @Test
+    public void createUser_validInputs_success() {
+        // createUser flow: checkIfUserExists (findByUsername + findByEmailAddress)
+        // → save → loginUser (findByUsername again to verify user exists).
+        // So findByUsername is called twice: first for uniqueness (must return null),
+        // then for login lookup (must return the saved user).
+        Mockito.when(userRepository.findByUsername("testUser"))
+                .thenReturn(null)       // first call: uniqueness check
+                .thenReturn(testUser);  // second call: login lookup
+        Mockito.when(userRepository.findByEmailAddress("john@example.com")).thenReturn(null);
 
-		// then
-		Mockito.verify(userRepository, Mockito.times(1)).save(Mockito.any());
+        // when: creating the user (createUser also calls loginUser internally)
+        User createdUser = userService.createUser(testUser);
 
-		assertEquals(testUser.getId(), createdUser.getId());
-		assertEquals(testUser.getName(), createdUser.getName());
-		assertEquals(testUser.getUsername(), createdUser.getUsername());
-		assertNotNull(createdUser.getToken());
-		assertEquals(UserStatus.OFFLINE, createdUser.getStatus());
-	}
+        // then: user is saved and gets a token from auto-login
+        Mockito.verify(userRepository, Mockito.times(1)).save(Mockito.any());
+        assertEquals("testUser", createdUser.getUsername());
+        assertEquals("John", createdUser.getSurname());
+        assertNotNull(createdUser.getToken());
+    }
 
-	@Test
-	public void createUser_duplicateName_throwsException() {
-		// given -> a first user has already been created
-		userService.createUser(testUser);
+    @Test
+    public void createUser_duplicateUsername_throwsException() {
+        // given: a user with the same username already exists
+        Mockito.when(userRepository.findByUsername("testUser")).thenReturn(testUser);
+        Mockito.when(userRepository.findByEmailAddress(Mockito.any())).thenReturn(null);
 
-		// when -> setup additional mocks for UserRepository
-		Mockito.when(userRepository.findByName(Mockito.any())).thenReturn(testUser);
-		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
+        // then: creating a user with a duplicate username throws an exception
+        assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
+    }
 
-		// then -> attempt to create second user with same user -> check that an error
-		// is thrown
-		assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
-	}
+    @Test
+    public void createUser_duplicateEmail_throwsException() {
+        // given: a user with the same email already exists
+        Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
+        Mockito.when(userRepository.findByEmailAddress("john@example.com")).thenReturn(testUser);
 
-	@Test
-	public void createUser_duplicateInputs_throwsException() {
-		// given -> a first user has already been created
-		userService.createUser(testUser);
+        // then: creating a user with a duplicate email throws an exception
+        assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
+    }
 
-		// when -> setup additional mocks for UserRepository
-		Mockito.when(userRepository.findByName(Mockito.any())).thenReturn(testUser);
-		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(testUser);
+    @Test
+    public void loginUser_validCredentials_success() {
+        // given: user exists in the database with matching password
+        Mockito.when(userRepository.findByUsername("testUser")).thenReturn(testUser);
 
-		// then -> attempt to create second user with same user -> check that an error
-		// is thrown
-		assertThrows(ResponseStatusException.class, () -> userService.createUser(testUser));
-	}
+        User loginInput = new User();
+        loginInput.setUsername("testUser");
+        loginInput.setPassword("testPassword");
 
+        // when: logging in
+        User loggedInUser = userService.loginUser(loginInput);
+
+        // then: a token is generated
+        assertNotNull(loggedInUser.getToken());
+        assertEquals("testUser", loggedInUser.getUsername());
+    }
+
+    @Test
+    public void loginUser_wrongPassword_throwsException() {
+        // given: user exists but we provide wrong password
+        Mockito.when(userRepository.findByUsername("testUser")).thenReturn(testUser);
+
+        User loginInput = new User();
+        loginInput.setUsername("testUser");
+        loginInput.setPassword("wrongPassword");
+
+        // then: login with wrong password throws UNAUTHORIZED
+        assertThrows(ResponseStatusException.class, () -> userService.loginUser(loginInput));
+    }
+
+    @Test
+    public void loginUser_nonExistentUser_throwsException() {
+        // given: no user with this username exists
+        Mockito.when(userRepository.findByUsername("ghostUser")).thenReturn(null);
+
+        User loginInput = new User();
+        loginInput.setUsername("ghostUser");
+        loginInput.setPassword("anyPassword");
+
+        // then: login with non-existent username throws NOT_FOUND
+        assertThrows(ResponseStatusException.class, () -> userService.loginUser(loginInput));
+    }
 }


### PR DESCRIPTION
- Rename isVolunteer()/setVolunteer() to getIsVolunteer()/setIsVolunteer()  in User entity and UserPostDTO so Jackson maps JSON 'isVolunteer' correctly (was silently ignored, defaulting to false on every registration)

- Add @Mapping(source='recipient.id', target='recipientId') for InseratGetDTO (recipientId was always null because MapStruct can't auto-map User -> String)

- Remove broken 'name' field and unused UserStatus import from UserGetDTO

- Remove duplicate GET /users/{id}/profile endpoint from UserController

- Rewrite all 5 test files to match current entity structure (old tests referenced removed fields: name, status, Long IDs, findByName)